### PR TITLE
Update Rustup profile, add other deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,8 @@ services: docker
 
 env:
 #VERSIONS
-  - VERSION=1.72.1 VARIANT=buster
-  - VERSION=1.72.1 VARIANT=buster/slim
-  - VERSION=1.72.1 VARIANT=bullseye
-  - VERSION=1.72.1 VARIANT=bullseye/slim
   - VERSION=1.72.1 VARIANT=bookworm
   - VERSION=1.72.1 VARIANT=bookworm/slim
-  - VERSION=1.72.1 VARIANT=alpine3.17
   - VERSION=1.72.1 VARIANT=alpine3.18
 #VERSIONS
 

--- a/1.72.1/alpine3.17/Dockerfile
+++ b/1.72.1/alpine3.17/Dockerfile
@@ -20,7 +20,7 @@ RUN set -eux; \
     wget "$url"; \
     echo "${rustupSha256} *rustup-init" | sha256sum -c -; \
     chmod +x rustup-init; \
-    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch}; \
+    ./rustup-init -y --no-modify-path --profile default --default-toolchain $RUST_VERSION --default-host ${rustArch}; \
     rm rustup-init; \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
     rustup --version; \

--- a/1.72.1/alpine3.18/Dockerfile
+++ b/1.72.1/alpine3.18/Dockerfile
@@ -3,6 +3,8 @@ FROM alpine:3.18
 RUN apk add --no-cache \
         ca-certificates \
         gcc \
+	openssh-client \
+	git \
         protoc protobuf-dev
 
 ENV RUSTUP_HOME=/usr/local/rustup \

--- a/1.72.1/alpine3.18/Dockerfile
+++ b/1.72.1/alpine3.18/Dockerfile
@@ -2,7 +2,8 @@ FROM alpine:3.18
 
 RUN apk add --no-cache \
         ca-certificates \
-        gcc
+        gcc \
+        protoc protobuf-dev
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
@@ -20,7 +21,7 @@ RUN set -eux; \
     wget "$url"; \
     echo "${rustupSha256} *rustup-init" | sha256sum -c -; \
     chmod +x rustup-init; \
-    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch}; \
+    ./rustup-init -y --no-modify-path --profile default --default-toolchain $RUST_VERSION --default-host ${rustArch}; \
     rm rustup-init; \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
     rustup --version; \

--- a/1.72.1/bookworm/Dockerfile
+++ b/1.72.1/bookworm/Dockerfile
@@ -8,7 +8,8 @@ ENV RUSTUP_HOME=/usr/local/rustup \
 RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
-        git \
+        openssh-client \
+	git \
 	neovim \
 	protobuf-compiler libprotobuf-dev;
     dpkgArch="$(dpkg --print-architecture)"; \

--- a/1.72.1/bookworm/Dockerfile
+++ b/1.72.1/bookworm/Dockerfile
@@ -6,6 +6,11 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     RUST_VERSION=1.72.1
 
 RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        git \
+	neovim \
+	protobuf-compiler libprotobuf-dev;
     dpkgArch="$(dpkg --print-architecture)"; \
     case "${dpkgArch##*-}" in \
         amd64) rustArch='x86_64-unknown-linux-gnu'; rustupSha256='0b2f6c8f85a3d02fde2efc0ced4657869d73fccfce59defb4e8d29233116e6db' ;; \
@@ -15,10 +20,10 @@ RUN set -eux; \
         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
     esac; \
     url="https://static.rust-lang.org/rustup/archive/1.26.0/${rustArch}/rustup-init"; \
-    wget "$url"; \
+    curl -o rustup-init "$url"; \
     echo "${rustupSha256} *rustup-init" | sha256sum -c -; \
     chmod +x rustup-init; \
-    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch}; \
+    ./rustup-init -y --no-modify-path --profile default --default-toolchain $RUST_VERSION --default-host ${rustArch}; \
     rm rustup-init; \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
     rustup --version; \

--- a/1.72.1/bookworm/slim/Dockerfile
+++ b/1.72.1/bookworm/slim/Dockerfile
@@ -13,7 +13,8 @@ RUN set -eux; \
         libc6-dev \
         procps \
         curl \
-        git \
+        openssh-client \
+	git \
         neovim \
         protobuf-compiler libprotobuf-dev; \
     dpkgArch="$(dpkg --print-architecture)"; \

--- a/1.72.1/bookworm/slim/Dockerfile
+++ b/1.72.1/bookworm/slim/Dockerfile
@@ -11,8 +11,11 @@ RUN set -eux; \
         ca-certificates \
         gcc \
         libc6-dev \
-        wget \
-        ; \
+        procps \
+        curl \
+        git \
+        neovim \
+        protobuf-compiler libprotobuf-dev; \
     dpkgArch="$(dpkg --print-architecture)"; \
     case "${dpkgArch##*-}" in \
         amd64) rustArch='x86_64-unknown-linux-gnu'; rustupSha256='0b2f6c8f85a3d02fde2efc0ced4657869d73fccfce59defb4e8d29233116e6db' ;; \
@@ -22,16 +25,13 @@ RUN set -eux; \
         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
     esac; \
     url="https://static.rust-lang.org/rustup/archive/1.26.0/${rustArch}/rustup-init"; \
-    wget "$url"; \
+    curl -o rustup-init "$url"; \
     echo "${rustupSha256} *rustup-init" | sha256sum -c -; \
     chmod +x rustup-init; \
-    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch}; \
+    ./rustup-init -y --no-modify-path --profile default --default-toolchain $RUST_VERSION --default-host ${rustArch}; \
     rm rustup-init; \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
     rustup --version; \
     cargo --version; \
     rustc --version; \
-    apt-get remove -y --auto-remove \
-        wget \
-        ; \
     rm -rf /var/lib/apt/lists/*;

--- a/1.72.1/bullseye/Dockerfile
+++ b/1.72.1/bullseye/Dockerfile
@@ -15,10 +15,10 @@ RUN set -eux; \
         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
     esac; \
     url="https://static.rust-lang.org/rustup/archive/1.26.0/${rustArch}/rustup-init"; \
-    wget "$url"; \
+    curl -o rustup-init "$url"; \
     echo "${rustupSha256} *rustup-init" | sha256sum -c -; \
     chmod +x rustup-init; \
-    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch}; \
+    ./rustup-init -y --no-modify-path --profile default --default-toolchain $RUST_VERSION --default-host ${rustArch}; \
     rm rustup-init; \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
     rustup --version; \

--- a/1.72.1/bullseye/slim/Dockerfile
+++ b/1.72.1/bullseye/slim/Dockerfile
@@ -11,7 +11,9 @@ RUN set -eux; \
         ca-certificates \
         gcc \
         libc6-dev \
-        wget \
+        curl \
+	git \
+	neovim \
         ; \
     dpkgArch="$(dpkg --print-architecture)"; \
     case "${dpkgArch##*-}" in \
@@ -22,16 +24,13 @@ RUN set -eux; \
         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
     esac; \
     url="https://static.rust-lang.org/rustup/archive/1.26.0/${rustArch}/rustup-init"; \
-    wget "$url"; \
+    curl -o rustup-init "$url"; \
     echo "${rustupSha256} *rustup-init" | sha256sum -c -; \
     chmod +x rustup-init; \
-    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch}; \
+    ./rustup-init -y --no-modify-path --profile default --default-toolchain $RUST_VERSION --default-host ${rustArch}; \
     rm rustup-init; \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
     rustup --version; \
     cargo --version; \
     rustc --version; \
-    apt-get remove -y --auto-remove \
-        wget \
-        ; \
     rm -rf /var/lib/apt/lists/*;

--- a/1.72.1/buster/Dockerfile
+++ b/1.72.1/buster/Dockerfile
@@ -15,10 +15,10 @@ RUN set -eux; \
         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
     esac; \
     url="https://static.rust-lang.org/rustup/archive/1.26.0/${rustArch}/rustup-init"; \
-    wget "$url"; \
+    curl -o rustup-init "$url"; \
     echo "${rustupSha256} *rustup-init" | sha256sum -c -; \
     chmod +x rustup-init; \
-    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch}; \
+    ./rustup-init -y --no-modify-path --profile default --default-toolchain $RUST_VERSION --default-host ${rustArch}; \
     rm rustup-init; \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
     rustup --version; \

--- a/1.72.1/buster/slim/Dockerfile
+++ b/1.72.1/buster/slim/Dockerfile
@@ -11,7 +11,9 @@ RUN set -eux; \
         ca-certificates \
         gcc \
         libc6-dev \
-        wget \
+        curl \
+	git \
+	neovim \
         ; \
     dpkgArch="$(dpkg --print-architecture)"; \
     case "${dpkgArch##*-}" in \
@@ -22,16 +24,13 @@ RUN set -eux; \
         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
     esac; \
     url="https://static.rust-lang.org/rustup/archive/1.26.0/${rustArch}/rustup-init"; \
-    wget "$url"; \
+    curl -o rustup-init "$url"; \
     echo "${rustupSha256} *rustup-init" | sha256sum -c -; \
     chmod +x rustup-init; \
-    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch}; \
+    ./rustup-init -y --no-modify-path --profile default --default-toolchain $RUST_VERSION --default-host ${rustArch}; \
     rm rustup-init; \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
     rustup --version; \
     cargo --version; \
     rustc --version; \
-    apt-get remove -y --auto-remove \
-        wget \
-        ; \
     rm -rf /var/lib/apt/lists/*;

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -2,7 +2,8 @@ FROM alpine:%%TAG%%
 
 RUN apk add --no-cache \
         ca-certificates \
-        gcc
+        gcc \
+        protoc protobuf-dev
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
@@ -15,7 +16,7 @@ RUN set -eux; \
     wget "$url"; \
     echo "${rustupSha256} *rustup-init" | sha256sum -c -; \
     chmod +x rustup-init; \
-    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch}; \
+    ./rustup-init -y --no-modify-path --profile default --default-toolchain $RUST_VERSION --default-host ${rustArch}; \
     rm rustup-init; \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
     rustup --version; \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -3,6 +3,8 @@ FROM alpine:%%TAG%%
 RUN apk add --no-cache \
         ca-certificates \
         gcc \
+	openssh-client \
+	git \
         protoc protobuf-dev
 
 ENV RUSTUP_HOME=/usr/local/rustup \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -8,7 +8,8 @@ ENV RUSTUP_HOME=/usr/local/rustup \
 RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
-        git \
+        openssh-client \
+	git \
 	neovim \
 	protobuf-compiler libprotobuf-dev;
     %%ARCH-CASE%%; \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -6,12 +6,17 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     RUST_VERSION=%%RUST-VERSION%%
 
 RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        git \
+	neovim \
+	protobuf-compiler libprotobuf-dev;
     %%ARCH-CASE%%; \
     url="https://static.rust-lang.org/rustup/archive/%%RUSTUP-VERSION%%/${rustArch}/rustup-init"; \
-    wget "$url"; \
+    curl -o rustup-init "$url"; \
     echo "${rustupSha256} *rustup-init" | sha256sum -c -; \
     chmod +x rustup-init; \
-    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch}; \
+    ./rustup-init -y --no-modify-path --profile default --default-toolchain $RUST_VERSION --default-host ${rustArch}; \
     rm rustup-init; \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
     rustup --version; \

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -11,20 +11,20 @@ RUN set -eux; \
         ca-certificates \
         gcc \
         libc6-dev \
-        wget \
-        ; \
+        procps \
+        curl \
+        git \
+        neovim \
+        protobuf-compiler libprotobuf-dev; \
     %%ARCH-CASE%%; \
     url="https://static.rust-lang.org/rustup/archive/%%RUSTUP-VERSION%%/${rustArch}/rustup-init"; \
-    wget "$url"; \
+    curl -o rustup-init "$url"; \
     echo "${rustupSha256} *rustup-init" | sha256sum -c -; \
     chmod +x rustup-init; \
-    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch}; \
+    ./rustup-init -y --no-modify-path --profile default --default-toolchain $RUST_VERSION --default-host ${rustArch}; \
     rm rustup-init; \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
     rustup --version; \
     cargo --version; \
     rustc --version; \
-    apt-get remove -y --auto-remove \
-        wget \
-        ; \
     rm -rf /var/lib/apt/lists/*;

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -13,7 +13,8 @@ RUN set -eux; \
         libc6-dev \
         procps \
         curl \
-        git \
+        openssh-client \
+	git \
         neovim \
         protobuf-compiler libprotobuf-dev; \
     %%ARCH-CASE%%; \

--- a/x.py
+++ b/x.py
@@ -19,8 +19,6 @@ debian_arches = [
 ]
 
 debian_variants = [
-    "buster",
-    "bullseye",
     "bookworm",
 ]
 
@@ -34,7 +32,6 @@ alpine_arches = [
 ]
 
 alpine_versions = [
-    "3.17",
     "3.18",
 ]
 


### PR DESCRIPTION
Changes the Rustup profile to "default" instead of "minimal" to be useful to IDEs and developers that want to see rust-doc help.  Adds some other system utilities required by the likes of VS Code or JetBrains IDEs to support Dev Containers workflow.  Finally, includes the gRPC/protobuf libraries packaged by the distros to be able to use Tokio/Tonic. 